### PR TITLE
Fixed line 104 of alicetrd-python/src/dcs/trdbox.py

### DIFF
--- a/src/dcs/trdbox.py
+++ b/src/dcs/trdbox.py
@@ -101,4 +101,4 @@ def read(ctx, address):
 @click.argument('data', callback=lambda c,p,x: int(x,0))
 @click.pass_context
 def write(ctx, address, data):
-    ctx.obj.exec(f"write {address} {cmd}")
+    ctx.obj.exec(f"write {address} {data}")


### PR DESCRIPTION
Line 104 of `alicetrd-python/src/dcs/trdbox.py` contained `{cmd}` which is not a variable previously defined for use in the `write` function. This raised a `{cmd} not found` error upon execution of the `trdbox write` command. This has been corrected.