### PR TITLE
Fixed line 104 of alicetrd-python/src/dcs/trdbox.py

### DIFF
--- a/src/dcs/trdbox.py
+++ b/src/dcs/trdbox.py
@@ -101,4 +101,4 @@ def read(ctx, address):
 @click.argument('data', callback=lambda c,p,x: int(x,0))
 @click.pass_context
 def write(ctx, address, data):
-    ctx.obj.exec(f"write {address} {cmd}")
+    ctx.obj.exec(f"write {address} {data}")


### PR DESCRIPTION
Line 104 contained `{cmd}` as a variable, however this variable was not defined for use in the `write` function. This led to `{cmd} not found` errors upon execution of `trdbox write` on the TRD computer. `{cmd}` has been changed to `{data}` based on the prior definition on line 101.