### PR TITLE
Added missing functionality for the unblock command

### DIFF
--- a/src/dcs/trdbox.py
+++ b/src/dcs/trdbox.py
@@ -58,6 +58,8 @@ def status(ctx):
         print(f"{r['name']:<10} [0x{r['addr']:03x}]: 0x{rd:08x} = {rd}")
 
 @trdbox.command()
+@click.argument('ch', callback=lambda c,p,x: int(x,0))
+@click.argument('thresh', callback=lambda c,p,x: int(x,0))
 @click.pass_context
 def unblock(ctx, ch, thresh):
     ctx.obj.exec(f"write {su704_pre_base+3} 1")


### PR DESCRIPTION
The `unblock` command was missing the following lines before it was defined: 
```python
@click.argument('ch', callback=lambda c,p,x: int(x,0))
@click.argument('thresh', callback=lambda c,p,x: int(x,0))
```
This has been corrected so that `trdbox unblock` now accepts the correct arguments from the command line.